### PR TITLE
Add information on the two different current formulas for LV8729.

### DIFF
--- a/calibration.html
+++ b/calibration.html
@@ -405,9 +405,13 @@
         <pre>VREF = (RMS current * 2.5) / 1.77</pre>
         <p>The process is then the same as for A4988s as shown in the video above.</p>
         <h4>LV8729</h4>
-        <p>When I tested these, there was no mention of a sense resistor. Therefore the VREF formula is simple:</p>
-        <p>The process is then the same as for A4988s as shown in the video above.</p>
+        <p>There are mainly two kinds of stepper driver boards with this driver.</p>
+        <p>One has a resistor labeled R100 on the bottom, and on the other the resistor is labeled R220. Which formula you use is based off of this resistor</p>
+        <p>The process is then mostly the same as for A4988s as shown in the video above, but with the correct formula for your driver board.</p>
+        <p>R100:</p>
         <pre>VREF = max current / 2</pre>
+        <p>R220:</p>
+        <pre>VREF = max current * 1.1</pre>
         <h2>2. Gcode</h2>
         <p>TMC drivers connected via UART or SPI serial can easily have their current set via gcode. This is not peak current, but rather RMS (root mean square) current. Rather than the maximum, think of this as more a typical/average current, where the driver will be operating mostly. To convert the peak current from stepper motor specs to RMS, divide it by <b>1.41</b>.</p>
         <p>The current can be set in a few different ways for each driver:</p>


### PR DESCRIPTION
I noticed that you didn't have any info on the R220 LV8729 stepper boards, which is a problem that plagued me when I was setting up new drivers on my printer. (constant stepper skipping due to wrong formula giving me too low of a VREF).

If you would also like a picture of the R220 variant for a diagram showing where to look, let me know and I can send you one. 