### PR TITLE
fix: Prevent donate container from encroaching on the page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -186,7 +186,7 @@ iframe {
 #donate {
     vertical-align: middle;
     float: right;
-    padding: 20px;
+    padding: 20px 20px 0 0;
 }
 
 #donate img {


### PR DESCRIPTION
Remove bottom padding from #donate to prevent responsive tabs from being pushed around. 

Before:
![image](https://user-images.githubusercontent.com/981915/90322593-04c41f00-df24-11ea-80c2-7c375d36a2a9.png)
After:
![image](https://user-images.githubusercontent.com/981915/90322601-15749500-df24-11ea-8eff-35623068e3af.png)
