### PR TITLE
Add Github repo link to bottom of page

### DIFF
--- a/calibration.html
+++ b/calibration.html
@@ -937,6 +937,7 @@
         <li><a href="https://fonts.google.com/specimen/Roboto" target="_blank">Roboto font</a></li>
         <li><a href="https://github.com/tedktedk/videobox" target="_blank">Videobox by tedktedk</a></li>
         <li><a href="https://github.com/noelboss/featherlight" target="_blank">Featherlight by noelboss</a></li>
+        <li><a href="https://github.com/teachingtechYT/teachingtechYT.github.io" target="_blank">Github Repository</a></li>        
     </ul>
 </div>
 </body>


### PR DESCRIPTION
I couldn't find a link to the github repo on the pages and only found it via the youtube video. I think it would be good to have a link readily available for people to find an contribute :)