### PR TITLE
potential fix for temperature tower getting confused

### DIFF
--- a/js/gcodeprocessing.js
+++ b/js/gcodeprocessing.js
@@ -322,7 +322,7 @@ function processTemperature(){
     if(abl == 4){
         temperature = temperature.replace(/G28 ; home all axes/, "M109 S170 T0 ; probing temperature\nG28 ; home all");
         temperature = temperature.replace(/;G29 ; probe ABL/, "G29 ; probe ABL");
-        temperature = temperature.replace(/;M420 S1 ; restore ABL mesh/, "M109 S500 T0");
+        temperature = temperature.replace(/;M420 S1 ; restore ABL mesh/, "M109 TEMP1 T0");
     }
     temperature = temperature.replace(/M140 S60/g, "M140 S"+bedTemp);
     temperature = temperature.replace(/M190 S60/g, "M190 S"+bedTemp);
@@ -370,18 +370,11 @@ function processTemperature(){
             temperature = temperatureArray.join("\n");
         }   
     }
-    if(abl != 4){
-        temperature = temperature.replace(/M104 S190/g, "M104 S"+a1);
-        temperature = temperature.replace(/M109 S190/g, "M109 S"+a1);
-    } else {
-        temperature = temperature.replace(/M104 S190/g, "; Prusa Mini");
-        temperature = temperature.replace(/M109 S190/g, "; Prusa Mini");
-        temperature = temperature.replace(/M109 S500/g, "M109 S"+a1);
-    }
-    temperature = temperature.replace(/M104 S195/g, "M104 S"+b1);
-    temperature = temperature.replace(/M104 S200/g, "M104 S"+c1);
-    temperature = temperature.replace(/M104 S205/g, "M104 S"+d1);
-    temperature = temperature.replace(/M104 S210/g, "M104 S"+e1);
+    temperature = temperature.replace(/TEMP1/g, "S"+a1);
+    temperature = temperature.replace(/TEMP2/g, "S"+b1);
+    temperature = temperature.replace(/TEMP3/g, "S"+c1);
+    temperature = temperature.replace(/TEMP4/g, "S"+d1);
+    temperature = temperature.replace(/TEMP5/g, "S"+e1);
     downloadFile('temperature.gcode', temperature);
 }
 

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -4,8 +4,8 @@ M82
 M106 S0
 M140 S60
 M190 S60
-M104 S190 T0
-M109 S190 T0
+M104 TEMP1 T0
+M109 TEMP1 T0
 G28 ; home all axes
 ;G29 ; probe ABL
 ;M420 S1 ; restore ABL mesh 
@@ -8154,7 +8154,7 @@ G92 E0.0000
 G1 E-5.0000 F2400
 ; process Color1-6-2
 ; layer 51, Z = 10.200
-M104 S195 T0
+M104 TEMP2 T0
 ; feature inner perimeter
 ; tool H0.200 W0.480
 G1 Z10.400 F1200
@@ -12148,7 +12148,7 @@ G92 E0.0000
 G1 E-5.0000 F2400
 ; process Color1-6-3
 ; layer 91, Z = 18.200
-M104 S200 T0
+M104 TEMP3 T0
 ; feature inner perimeter
 ; tool H0.200 W0.480
 G1 Z18.400 F1200
@@ -16142,7 +16142,7 @@ G92 E0.0000
 G1 E-5.0000 F2400
 ; process Color1-6-4
 ; layer 131, Z = 26.200
-M104 S205 T0
+M104 TEMP4 T0
 ; feature inner perimeter
 ; tool H0.200 W0.480
 G1 Z26.400 F1200
@@ -20136,7 +20136,7 @@ G92 E0.0000
 G1 E-5.0000 F2400
 ; process Color1-6-5
 ; layer 171, Z = 34.200
-M104 S210 T0
+M104 TEMP5 T0
 ; feature inner perimeter
 ; tool H0.200 W0.480
 G1 Z34.400 F1200


### PR DESCRIPTION
As observed in issue #22, temperatures can get messed up.  I think this occurs if some of the replacement temperatures match the original template temperatures, in which case they get replaced again.

By changing the template to have TEMP1, TEMP2, TEMP3, TEMP4, and TEMP5, this is avoided.  And the goofy 500 degree temperature is not needed anymore.