### PR TITLE
Persist textarea and input text

### DIFF
--- a/js/persist.js
+++ b/js/persist.js
@@ -16,6 +16,8 @@ function loadFormData(form) {
       element.tagName == "INPUT" && element.type == "number" ||
       element.tagName == "INPUT" && element.type == "checkbox" ||
       element.tagName == "INPUT" && element.type == "radio" ||
+      element.tagName == "INPUT" && element.type == "text" ||
+      element.tagName == "TEXTAREA" ||
       element.tagName == "SELECT"
     ) {
       var newValue = getPeristedValue(element);


### PR DESCRIPTION
Follow-up after: https://github.com/teachingtechYT/teachingtechYT.github.io/pull/54#issuecomment-675336019

Persist:
- `<textarea>`
- `<input type="text">`

