### PR TITLE
Change order of temps in temperature test

### DIFF
--- a/calibration.html
+++ b/calibration.html
@@ -928,11 +928,11 @@
                             <img src="img/temperaturediagram.jpg" />
                         </td>
                         <td style="text-align: center;">E</td>
-                        <td><input type="number" min="150" max="450" name="temp_e1" value="210"></td>
+                        <td><input type="number" min="150" max="450" name="temp_e1" value="190"></td>
                     </tr>
                     <tr>
                         <td style="text-align: center;">D</td>
-                        <td><input type="number" min="150" max="450" name="temp_d1" value="205"></td>
+                        <td><input type="number" min="150" max="450" name="temp_d1" value="195"></td>
                     </tr>
                     <tr>
                         <td style="text-align: center;">C</td>
@@ -940,11 +940,11 @@
                     </tr>
                     <tr>
                         <td style="text-align: center;">B</td>
-                        <td><input type="number" min="150" max="450" name="temp_b1" value="195"></td>
+                        <td><input type="number" min="150" max="450" name="temp_b1" value="205"></td>
                     </tr>
                     <tr>
                         <td style="text-align: center;">A</td>
-                        <td><input type="number" min="150" max="450" name="temp_a1" value="190"></td>
+                        <td><input type="number" min="150" max="450" name="temp_a1" value="210"></td>
                     </tr>
                     <tr>
                         <td style="text-align: center;">First layer</td>


### PR DESCRIPTION
This is in order to prevent a bad extrusion on low temperatures and continue to print on that.
Going from hot to cold temperatures let you see what is your lower temperature without affecting other segments (and needs to regenerate a test).
I think this as default makes more sense ;)