### PR TITLE
Updated navigation path to top layers in PrusaSlicer

### DIFF
--- a/calibration.html
+++ b/calibration.html
@@ -401,7 +401,7 @@
                     <td>3. Turn off top layers</td>
                     <td>Shell > Top/bottom thickness > Top layers: 0</td>
                     <td>Layer > Top solid layers: 0</td>
-                    <td>Print settings > Layers and perimeters > Horizontal layers > Top: 0</td>
+                    <td>Print settings > Layers and perimeters > Horizontal shells > Solid layers > Top: 0</td>
                 </tr>
                 <tr>
                     <td>4. Ensure wall thickness is a known value.<br />Substitute whatever values you like here. This example uses <b>0.4</b>, which is common for a 0.4mm nozzle and 0.2mm layer height.</td>


### PR DESCRIPTION
Small update to make it easier to find where Top Layers are in the latest version of PrusaSlicer (see screenshot):

![image](https://user-images.githubusercontent.com/309969/111775102-b0509b80-8886-11eb-9657-579c44424a65.png)
