### PR TITLE
Patch 1

### DIFF
--- a/js/commongcode.js
+++ b/js/commongcode.js
@@ -13,7 +13,7 @@ G28 ; home all axes
 ;M420 S1 ; restore ABL mesh 
 ;customstart
 G92 E0.0 ; set current extruder position as 0
-M82; switch to extruder absolute mode
+G90 ; set all axes back to absolute mode
 G0 Z3; fix for delta printers that home at max`;
 
 var commonEnd = `

--- a/js/commongcode.js
+++ b/js/commongcode.js
@@ -12,6 +12,8 @@ G28 ; home all axes
 ;G29 ; probe ABL
 ;M420 S1 ; restore ABL mesh 
 ;customstart
+G92 E0.0 ; set current extruder position as 0
+M82; switch to extruder absolute mode
 G0 Z3; fix for delta printers that home at max`;
 
 var commonEnd = `


### PR DESCRIPTION
The Simplify3D generated G-Code uses absolute extruder and XYZ position values. If the user's custom start gcode sets it to relative and fails to set it back, the printer will be operating in the wrong mode.

Notably PrusaSlicer profiles for Prusa machines includes start g-code that sets the extruder to relative mode (M83) and doesn't change it back.