### PR TITLE
[Typo] Balance parentheses on PID Autotune page

### DIFF
--- a/calibration.html
+++ b/calibration.html
@@ -199,10 +199,10 @@
             <p>In this case, you need to insert <b>M301</b> (hot end) or <b>M304</b> (bed) into your slicer start gcode so the correct settings are loaded before each print.</p>
             <p>After PID auto tuning, the final values for P, I and D will be listed in the terminal. Retreive them and use them as follows for the hot end:</p>
             <pre>M301 E0 P[p value] I[i value] D[d value]</pre>
-            <p>This will set the PID values for the default hot end, eg. <b>M301 E0 P34.4 I0.02 D5.7</b> (bogus numbers, please don't copy them.</p>
+            <p>This will set the PID values for the default hot end, eg. <b>M301 E0 P34.4 I0.02 D5.7</b> (bogus numbers, please don't copy them).</p>
             <p>For the bed:</p>
             <pre>M304 P[p value] I[i value] D[d value]</pre>
-            <p>This will set the PID values for the bed, eg. <b>M304 P26.0 I1.33 D20.5</b> (bogus numbers, please don't copy them.</p>
+            <p>This will set the PID values for the bed, eg. <b>M304 P26.0 I1.33 D20.5</b> (bogus numbers, please don't copy them).</p>
         </div>
     </div>
 


### PR DESCRIPTION
This PR is a minor typo fix, balancing two sets of unbalanced parentheses on the PID Autotune page, inside `calibration.html`.