### PR TITLE
Fix mobile view

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -248,7 +248,7 @@ iframe {
 
 #header {
     height: 4.0em;
-    margin-bottom:20px;
+    margin-bottom:100px;
 }
 
 .sug {
@@ -487,4 +487,4 @@ button {
 	background-color: #fff;
 
 	cursor: pointer;
-} 
+}

--- a/js/dynamic.js
+++ b/js/dynamic.js
@@ -42,7 +42,7 @@ $('#footer').html(footer);
 
 $(document).ready(function(){
     $('#tabs').responsiveTabs({
-        startCollapsed: 'accordion'
+        startCollapsed: 'tabs'
     });
     $(".videoThumb").videoBox({
         width: '480',


### PR DESCRIPTION
This fixes the logo being overlapped by the tabs and shows the tabs a proper way.

![mobileview](https://user-images.githubusercontent.com/1208190/130538954-37201cf2-4742-4425-85fc-d7487f872d83.png)
