### PR TITLE
Remove all T0 commands, not just the first one

### DIFF
--- a/js/gcodeprocessing.js
+++ b/js/gcodeprocessing.js
@@ -693,7 +693,7 @@ function processGcode(formName) {
         gcode = gcode.replace(/;M80/, "M80");
     }
     if(formName.removet0.checked == true) {
-        gcode = gcode.replace(/T0\n/, ";T0\n");
+        gcode = gcode.replace(/T0\n/g, ";T0\n");
     }
     if(formName.start.checked == true) {
         gcode = gcode.replace(/;customstart/, "; custom start gcode\n"+customStart);


### PR DESCRIPTION
Fix for issue #391 

Changed regex to do a global replace instead of a single replace.  This will remove all instances of the T0 command instead of just the first one.